### PR TITLE
Ensure std::getline always 0-terminates string.

### DIFF
--- a/include/istream
+++ b/include/istream
@@ -1069,16 +1069,18 @@ basic_istream<_CharT, _Traits>::getline(char_type* __s, streamsize __n, char_typ
                 this->rdbuf()->sbumpc();
                 ++__gc_;
             }
-            if (__n > 0)
-                *__s = char_type();
             if (__gc_ == 0)
                __err |= ios_base::failbit;
             this->setstate(__err);
         }
+        if (__n > 0)
+            *__s = char_type();
 #ifndef _LIBCPP_NO_EXCEPTIONS
     }
     catch (...)
     {
+        if (__n > 0)
+            *__s = char_type();
         this->__set_badbit_and_consider_rethrow();
     }
 #endif  // _LIBCPP_NO_EXCEPTIONS


### PR DESCRIPTION
If the sentinel failed (e.g. due to having reached
EOF before) or an exception was caught it failed to
do that.
While it seems (unfortunately!) not required by the
specification, libstdc++ does 0-terminate and not
doing so risks creating security issues in applications.

Sending as pull request, because bugzilla sure has been made maximum pain to use with not even new user registrations working automated.