### PR TITLE
Optimize std::midpoint

### DIFF
--- a/include/numeric
+++ b/include/numeric
@@ -532,17 +532,14 @@ midpoint(_Tp __a, _Tp __b) noexcept
 _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK
 {
     using _Up = std::make_unsigned_t<_Tp>;
+    constexpr _Up __bitshift = std::numeric_limits<_Up>::digits - 1;
 
-    int __sign = 1;
-    _Up __m = __a;
-    _Up __M = __b;
-    if (__a > __b)
-    {
-        __sign = -1;
-        __m = __b;
-        __M = __a;
-    }
-     return __a + __sign * _Tp(_Up(__M-__m) >> 1);
+    _Up __diff = _Up(__b) - _Up(__a);
+    _Up __sign_bit = __b < __a;
+
+    _Up __half_diff = (__diff / 2) + (__sign_bit << __bitshift) + (__sign_bit & __diff);
+
+    return __a + __half_diff;
 }
 
 


### PR DESCRIPTION
Marshall's talk (https://www.youtube.com/watch?v=sBtAGxBh-XI&t=1589s) inspired me to optimize this a bit more.

My code is the same idea as the current algorithm, that is, add (half of the difference between a and b) to a.

But we use a different technique for computing the difference: we compute b - a into a pair of integers that are named "__sign_bit" and "__diff".  We have to use two because, for example, subtracting two 32-bit integers produces a 33-bit result.

Computing half of that is a simple matter of shifting __diff right by 1, and adding __sign_bit shifted left by 31.

The only tricky part is that if the difference is odd and negative, then shifting it by one isn't the same as dividing it by two - shifting a negative one produces a negative one, for example.  So there's one more adjustment: if the sign bit and the low bit of diff are one, we add one.

Here's a demonstration of the codegen difference, as well as some testing: https://godbolt.org/z/7ar3K90
