### PR TITLE
[libcxx] Add support for reinterpret_pointer_cast

### DIFF
--- a/include/memory
+++ b/include/memory
@@ -4630,7 +4630,7 @@ const_pointer_cast(const shared_ptr<_Up>& __r) _NOEXCEPT
 }
 
 template<class _Tp, class _Up>
-shared_ptr<_Tp> reinterpret_pointer_cast(const shared_ptr<_UP>& __r) _NOEXCEPT
+shared_ptr<_Tp> reinterpret_pointer_cast(const shared_ptr<_Up>& __r) _NOEXCEPT
 {
     return shared_ptr<_Tp>(__r, reinterpret_cast<_Tp*>(__r.get()));
 }

--- a/include/memory
+++ b/include/memory
@@ -4629,6 +4629,12 @@ const_pointer_cast(const shared_ptr<_Up>& __r) _NOEXCEPT
     return shared_ptr<_Tp>(__r, const_cast<_RTp*>(__r.get()));
 }
 
+template<class _Tp, class _Up>
+shared_ptr<_Tp> reinterpret_pointer_cast(const shared_ptr<_UP>& __r) _NOEXCEPT
+{
+    return shared_ptr<_Tp>(__r, reinterpret_cast<_Tp*>(__r.get()));
+}
+
 #ifndef _LIBCPP_NO_RTTI
 
 template<class _Dp, class _Tp>

--- a/include/memory
+++ b/include/memory
@@ -492,6 +492,8 @@ template<class T, class U>
     shared_ptr<T> dynamic_pointer_cast(shared_ptr<U> const& r) noexcept;
 template<class T, class U>
     shared_ptr<T> const_pointer_cast(shared_ptr<U> const& r) noexcept;
+template<class T, class U>
+    shared_ptr<T> reinterpret_pointer_cast(shared_ptr<U> const& r) noexcept;
 
 // shared_ptr I/O:
 template<class E, class T, class Y>

--- a/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.cast/reinterpret_pointer_cast.pass.cpp
+++ b/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.cast/reinterpret_pointer_cast.pass.cpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <memory>
+
+// shared_ptr
+
+// template<class T, class U> shared_ptr<T> reinterpret_pointer_cast(const shared_ptr<U>& r);
+
+#include <memory>
+#include <type_traits>
+#include <cassert>
+
+#include "test_macros.h"
+
+struct B
+{
+    static int count;
+
+    B() {++count;}
+    B(const B&) {++count;}
+    virtual ~B() {--count;}
+};
+
+int B::count = 0;
+
+struct A
+    : public B
+{
+    static int count;
+
+    A() {++count;}
+    A(const A&) {++count;}
+    ~A() {--count;}
+};
+
+int A::count = 0;
+
+int main(int, char**)
+{
+    {
+        const std::shared_ptr<A> pA(new A);
+        std::shared_ptr<B> pB = std::reinterpret_pointer_cast<B>(pA);
+        assert(pB.get() == pA.get());
+        assert(!pB.owner_before(pA) && !pA.owner_before(pB));
+    }
+    {
+        const std::shared_ptr<B> pA(new A);
+        std::shared_ptr<A> pB = std::reinterpret_pointer_cast<A>(pA);
+        assert(pB.get() == pA.get());
+        assert(!pB.owner_before(pA) && !pA.owner_before(pB));
+    }
+    {
+        const std::shared_ptr<A> pA;
+        std::shared_ptr<B> pB = std::reinterpret_pointer_cast<B>(pA);
+        assert(pB.get() == pA.get());
+        assert(!pB.owner_before(pA) && !pA.owner_before(pB));
+    }
+    {
+        const std::shared_ptr<B> pA;
+        std::shared_ptr<A> pB = std::reinterpret_pointer_cast<A>(pA);
+        assert(pB.get() == pA.get());
+        assert(!pB.owner_before(pA) && !pA.owner_before(pB));
+    }
+
+  return 0;
+}


### PR DESCRIPTION
Add support for [std::reinterpret_pointer_cast](https://en.cppreference.com/w/cpp/memory/shared_ptr/pointer_cast).